### PR TITLE
added id and name settings to all input elements(Id and name have the same value )

### DIFF
--- a/public/fb.js
+++ b/public/fb.js
@@ -207,8 +207,12 @@ $(document).ready(function(){
       inputs.push($(".popover textarea")[0]);
       $.each(inputs, function(i,e){
       var vartype = $(e).attr("id");
-      var value = $active_component.find('[data-valtype="'+vartype+'"]')
-      if(vartype==="placeholder"){
+      var value = $active_component.find('[data-valtype="'+vartype+'"]');
+      if(vartype==="id"){
+		value = $active_component.find('[data-valtype="placeholder"]');
+        $(value).attr("id", $(e).val());
+		$(value).attr("name", $(e).val());
+      } else if(vartype==="placeholder"){
         $(value).attr("placeholder", $(e).val());
       } else if (vartype==="checkbox"){
         if($(e).is(":checked")){

--- a/public/fb.js
+++ b/public/fb.js
@@ -152,8 +152,11 @@ $(document).ready(function(){
       var valID ="#" + $(e).attr("data-valtype");
       var val;
       if(valID ==="#placeholder"){
-        val = $(e).attr("placeholder");
+        val = $(e).attr("placeholder");		
         $(".popover " + valID).val(val);
+		val_id = $(e).attr("id");
+		$(".popover #id").val(val_id);
+		$(".popover #name").val(val_id);
       } else if(valID==="#checkbox"){
         val = $(e).attr("checked");
         $(".popover " + valID).attr("checked",val);

--- a/public/index.html
+++ b/public/index.html
@@ -118,6 +118,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
+						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -128,7 +129,7 @@
                       <!-- Text input-->
                       <label class="control-label valtype" for="input01" data-valtype='label'>Text input</label>
                       <div class="controls">
-                        <input type="text" placeholder="placeholder" class="input-xlarge valtype" data-valtype="placeholder" >
+                        <input type="text" placeholder="placeholder" class="input-xlarge valtype" data-valtype="placeholder"  id="text" name="text">
                         <p class="help-block valtype" data-valtype='help'>Supporting help text</p>
                       </div>
                     </div>
@@ -140,6 +141,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
+						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -150,7 +152,7 @@
                       <!-- Search input-->
                       <label class="control-label valtype" data-valtype="label">Search input</label>
                       <div class="controls">
-                        <input type="text" placeholder="placeholder" class="input-xlarge search-query valtype" data-valtype="placeholder">
+                        <input type="text" placeholder="placeholder" class="input-xlarge search-query valtype" data-valtype="placeholder"  id="text" name="text">
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
 
@@ -164,6 +166,7 @@
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Prepend</label> <input type='text' name='prepend' id='prepend'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
+						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -176,7 +179,7 @@
                       <div class="controls">
                         <div class="input-prepend">
                           <span class="add-on valtype" data-valtype="prepend">^_^</span>
-                          <input class="span2 valtype" placeholder="placeholder" id="prependedInput" type="text" data-valtype="placeholder">
+                          <input class="span2 valtype" placeholder="placeholder" id="prependedInput" type="text" data-valtype="placeholder"  id="text" name="text">
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
@@ -190,6 +193,7 @@
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Appepend</label> <input type='text' name='append' id='append'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
+						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -201,7 +205,7 @@
                       <label class="control-label valtype" data-valtype="label">Appended text</label>
                       <div class="controls">
                         <div class="input-append">
-                          <input class="span2 valtype" data-valtype="placeholder" placeholder="placeholder" type="text">
+                          <input class="span2 valtype" data-valtype="placeholder" placeholder="placeholder" type="text" id="text" name="text">
                           <span class="add-on valtype" data-valtype="append">^_^</span>
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
@@ -215,6 +219,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
+						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <label class='checkbox'><input type='checkbox' class='input-inline' name='checked' id='checkbox'>Checked</label>
                           <hr/>
@@ -232,7 +237,7 @@
                               <input type="checkbox" class="valtype" data-valtype="checkbox">
                             </label>
                           </span>
-                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder">
+                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="text" name="text">
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
@@ -245,6 +250,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
+						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <label class='checkbox'><input type='checkbox' class='input-inline' name='checked' id='checkbox'>Checked</label>
                           <hr/>
@@ -257,7 +263,7 @@
                       <label class="control-label valtype" data-valtype="label">Append checkbox</label>
                       <div class="controls">
                         <div class="input-append">
-                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder">
+                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="text" name="text">
                           <span class="add-on">
                             <label class="checkbox" for="appendedCheckbox">
                               <input type="checkbox" class="valtype" data-valtype="checkbox">

--- a/public/index.html
+++ b/public/index.html
@@ -129,7 +129,7 @@
                       <!-- Text input-->
                       <label class="control-label valtype" for="input01" data-valtype='label'>Text input</label>
                       <div class="controls"> 
-                        <input type="text" placeholder="placeholder" class="input-xlarge valtype" data-valtype="placeholder"  id="" name="">
+                        <input type="text" placeholder="placeholder" class="input-xlarge valtype" data-valtype="placeholder" >
                         <p class="help-block valtype" data-valtype='help'>Supporting help text</p>
                       </div>
                     </div>
@@ -152,7 +152,7 @@
                       <!-- Search input-->
                       <label class="control-label valtype" data-valtype="label">Search input</label>
                       <div class="controls">
-                        <input type="text" placeholder="placeholder" class="input-xlarge search-query valtype" data-valtype="placeholder"  id="" name="">
+                        <input type="text" placeholder="placeholder" class="input-xlarge search-query valtype" data-valtype="placeholder" >
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
 
@@ -179,7 +179,7 @@
                       <div class="controls">
                         <div class="input-prepend">
                           <span class="add-on valtype" data-valtype="prepend">^_^</span>
-                          <input class="span2 valtype" placeholder="placeholder" id="prependedInput" type="text" data-valtype="placeholder"  id="" name="">
+                          <input class="span2 valtype" placeholder="placeholder" id="prependedInput" type="text" data-valtype="placeholder" >
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
@@ -205,7 +205,7 @@
                       <label class="control-label valtype" data-valtype="label">Appended text</label>
                       <div class="controls">
                         <div class="input-append">
-                          <input class="span2 valtype" data-valtype="placeholder" placeholder="placeholder" type="text" id="" name="">
+                          <input class="span2 valtype" data-valtype="placeholder" placeholder="placeholder" type="text" >
                           <span class="add-on valtype" data-valtype="append">^_^</span>
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
@@ -237,7 +237,7 @@
                               <input type="checkbox" class="valtype" data-valtype="checkbox">
                             </label>
                           </span>
-                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="" name="">
+                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder" >
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
@@ -263,7 +263,7 @@
                       <label class="control-label valtype" data-valtype="label">Append checkbox</label>
                       <div class="controls">
                         <div class="input-append">
-                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="" name="">
+                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder" >
                           <span class="add-on">
                             <label class="checkbox" for="appendedCheckbox">
                               <input type="checkbox" class="valtype" data-valtype="checkbox">

--- a/public/index.html
+++ b/public/index.html
@@ -118,7 +118,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
-						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
+        <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -128,8 +128,8 @@
 
                       <!-- Text input-->
                       <label class="control-label valtype" for="input01" data-valtype='label'>Text input</label>
-                      <div class="controls">
-                        <input type="text" placeholder="placeholder" class="input-xlarge valtype" data-valtype="placeholder"  id="text" name="text">
+                      <div class="controls"> 
+                        <input type="text" placeholder="placeholder" class="input-xlarge valtype" data-valtype="placeholder"  id="" name="">
                         <p class="help-block valtype" data-valtype='help'>Supporting help text</p>
                       </div>
                     </div>
@@ -141,7 +141,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
-						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
+        <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -152,7 +152,7 @@
                       <!-- Search input-->
                       <label class="control-label valtype" data-valtype="label">Search input</label>
                       <div class="controls">
-                        <input type="text" placeholder="placeholder" class="input-xlarge search-query valtype" data-valtype="placeholder"  id="text" name="text">
+                        <input type="text" placeholder="placeholder" class="input-xlarge search-query valtype" data-valtype="placeholder"  id="" name="">
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
 
@@ -166,7 +166,7 @@
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Prepend</label> <input type='text' name='prepend' id='prepend'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
-						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
+        <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -179,7 +179,7 @@
                       <div class="controls">
                         <div class="input-prepend">
                           <span class="add-on valtype" data-valtype="prepend">^_^</span>
-                          <input class="span2 valtype" placeholder="placeholder" id="prependedInput" type="text" data-valtype="placeholder"  id="text" name="text">
+                          <input class="span2 valtype" placeholder="placeholder" id="prependedInput" type="text" data-valtype="placeholder"  id="" name="">
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
@@ -193,7 +193,7 @@
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Appepend</label> <input type='text' name='append' id='append'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
-						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
+        <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <hr/>
                           <button class='btn btn-info'>Save</button><button class='btn btn-danger'>Cancel</button>
@@ -205,7 +205,7 @@
                       <label class="control-label valtype" data-valtype="label">Appended text</label>
                       <div class="controls">
                         <div class="input-append">
-                          <input class="span2 valtype" data-valtype="placeholder" placeholder="placeholder" type="text" id="text" name="text">
+                          <input class="span2 valtype" data-valtype="placeholder" placeholder="placeholder" type="text" id="" name="">
                           <span class="add-on valtype" data-valtype="append">^_^</span>
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
@@ -219,7 +219,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
-						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
+        <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <label class='checkbox'><input type='checkbox' class='input-inline' name='checked' id='checkbox'>Checked</label>
                           <hr/>
@@ -237,7 +237,7 @@
                               <input type="checkbox" class="valtype" data-valtype="checkbox">
                             </label>
                           </span>
-                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="text" name="text">
+                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="" name="">
                         </div>
                         <p class="help-block valtype" data-valtype="help">Supporting help text</p>
                       </div>
@@ -250,7 +250,7 @@
                         <div class='controls'>
                           <label class='control-label'>Label Text</label> <input class='input-large' type='text' name='label' id='label'>
                           <label class='control-label'>Placeholder</label> <input type='text' name='placeholder' id='placeholder'>
-						  <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
+        <label class='control-label'>ID/Name</label> <input type='text' name='id' id='id'>
                           <label class='control-label'>Help Text</label> <input type='text' name='help' id='help'>
                           <label class='checkbox'><input type='checkbox' class='input-inline' name='checked' id='checkbox'>Checked</label>
                           <hr/>
@@ -263,7 +263,7 @@
                       <label class="control-label valtype" data-valtype="label">Append checkbox</label>
                       <div class="controls">
                         <div class="input-append">
-                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="text" name="text">
+                          <input class="span2 valtype" placeholder="placeholder" type="text" data-valtype="placeholder"  id="" name="">
                           <span class="add-on">
                             <label class="checkbox" for="appendedCheckbox">
                               <input type="checkbox" class="valtype" data-valtype="checkbox">


### PR DESCRIPTION
The following problems has been fixed:

having an id set by default to eg. "text" means that you will have overlapping id's if you don't set them.
The form in the popover isn't being populated by the id / name if it is set i.e. set an id -> save -> click again to set id & it's blank.
mixed tabs & spaces
