### PR TITLE
Dragging a component while the popup is open keeps the popup div in the page.

### DIFF
--- a/public/fb.js
+++ b/public/fb.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
   $("form").delegate(".component", "mousedown", function(md){
-    $(".popover").hide();
+    $(".popover").remove();
 
     md.preventDefault();
     var tops = [];


### PR DESCRIPTION
If a component is dragged while a popup window is still open, the HTML `div` for the popup will not be removed, and will instead be hidden (`$(".popover").hide();` in fb.js line 3).

Besides populating the page with new `div` popup elements every time this happens, changes applied to the component by opening the properties popup afterwards will not take into effect, even if we remove and re-add the component.

Easiest way to reproduce:
1. Add a checkbox
2. Open the component's properties popup by clicking on it
3. Without closing the popup, drag the component. The HTML `<div>` for the popup will remain in the page.
4. Open the component's properties popup again. Changes will no longer be applied, even if we remove it and re-added.

This fix changes the `$(".popover").hide();` into `.remove()`.
