### PR TITLE
Resize vertical for textarea

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -29,6 +29,10 @@ input {
   cursor: pointer;
 }
 
+textarea {
+  resize: vertical;
+}
+
 .popover .control-group {
   cursor: default;
 }
@@ -104,5 +108,3 @@ form .popover form {
  width: 100%;
  overflow: hidden;
 }
-
-


### PR DESCRIPTION
I've added `resize: vertical` for `textarea`, in CSS to prevent resizing in horizontal mode.

This will allows us to resize the textareas only in vertical mode:

``` CSS
textarea {
    resize: vertical;
}
```
