### PR TITLE
Avoid useless placeholder attributes

### DIFF
--- a/assets/js/templates/snippet/appendedcheckbox.html
+++ b/assets/js/templates/snippet/appendedcheckbox.html
@@ -3,7 +3,13 @@
   <label class="control-label" for="<%- id %>"><%- label %></label>
   <div class="controls">
     <div class="input-append">
-      <input id="<%- id %>" name="<%- id %>" class="span2" type="text" placeholder="<%- placeholder %>" <% if(required) {%> required <% } %> />
+      <input
+        id="<%- id %>"
+        name="<%- id %>"
+        class="span2"
+        type="text"
+        <% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+      />
       <span class="add-on">
         <input type="checkbox"<% if (checked){ %> checked <% } %>>
       </span>

--- a/assets/js/templates/snippet/appendedtext.html
+++ b/assets/js/templates/snippet/appendedtext.html
@@ -3,7 +3,14 @@
   <label class="control-label" for="<%- id %>"><%- label %></label>
   <div class="controls">
     <div class="input-append">
-      <input id="<%- id %>" name="<%- id %>" class="<%- inputsize %>" placeholder="<%- placeholder %>" type="text"<% if(required) {%> required <% } %> />
+      <input
+      	id="<%- id %>"
+      	name="<%- id %>"
+      	class="<%- inputsize %>"
+      	<% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+      	type="text"
+      	<% if(required) {%> required <% } %>
+      />
       <span class="add-on"><%- append %></span>
     </div>
     <% if (helptext.length > 0) { %><p class="help-block"><%- helptext %></p><% } %>

--- a/assets/js/templates/snippet/buttondropdown.html
+++ b/assets/js/templates/snippet/buttondropdown.html
@@ -3,7 +3,14 @@
   <label class="control-label" for="<%- id %>"><%- label %></label>
   <div class="controls">
     <div class="input-append">
-      <input id="<%- id %>" name="<%- id %>" class="<%- inputsize %>" placeholder="<%- placeholder %>" type="text" <% if(required) {%> required <% } %> />
+      <input
+        id="<%- id %>"
+        name="<%- id %>"
+        class="<%- inputsize %>"
+        <% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+        type="text"
+        <% if(required) {%> required <% } %>
+      />
       <div class="btn-group">
         <button class="btn dropdown-toggle" data-toggle="dropdown">
           <%- buttontext %>

--- a/assets/js/templates/snippet/passwordinput.html
+++ b/assets/js/templates/snippet/passwordinput.html
@@ -2,7 +2,14 @@
 <div class="control-group">
   <label class="control-label" for="<%- id %>"><%- label %></label>
   <div class="controls">
-    <input id="<%- id %>" name="<%- id %>" type="password" placeholder="<%- placeholder %>" class="<%- inputsize %>" <% if(required) {%> required <% } %> />
+    <input
+		id="<%- id %>"
+		name="<%- id %>"
+		type="password"
+		<% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+		class="<%- inputsize %>"
+		<% if(required) {%> required <% } %>
+	/>
     <% if (helptext.length > 0) { %><p class="help-block"><%- helptext %></p><% } %>
   </div>
 </div>

--- a/assets/js/templates/snippet/prependedcheckbox.html
+++ b/assets/js/templates/snippet/prependedcheckbox.html
@@ -8,7 +8,14 @@
           <input type="checkbox" <% if (checked){ %>checked="checked"<% } %>>
         </label>
       </span>
-      <input id="<%- id %>" name="<%- id %>" class="<%- inputsize %>" type="text" placeholder="<%- placeholder %>" <% if(required) {%> required <% } %> />
+      <input
+        id="<%- id %>"
+        name="<%- id %>"
+        class="<%- inputsize %>"
+        type="text"
+        <% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+        <% if(required) {%> required <% } %>
+      />
     </div>
     <% if (helptext.length > 0) { %><p class="help-block"><%- helptext %></p><% } %>
   </div>

--- a/assets/js/templates/snippet/prependedtext.html
+++ b/assets/js/templates/snippet/prependedtext.html
@@ -4,7 +4,14 @@
   <div class="controls">
     <div class="input-prepend">
       <span class="add-on"><%- prepend %></span>
-      <input id="<%- id %>" name="<%- id %>" class="<%- inputsize %>" placeholder="<%- placeholder %>" type="text"<% if(required) {%> required <% } %> />
+      <input
+      	id="<%- id %>"
+      	name="<%- id %>"
+      	class="<%- inputsize %>"
+      	<% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+      	type="text"
+      	<% if(required) {%> required <% } %>
+      />
     </div>
     <% if (helptext.length > 0) { %><p class="help-block"><%- helptext %></p><% } %>
   </div>

--- a/assets/js/templates/snippet/searchinput.html
+++ b/assets/js/templates/snippet/searchinput.html
@@ -2,7 +2,14 @@
 <div class="control-group">
   <label class="control-label" for="<%- id %>"><%- label %></label>
   <div class="controls">
-    <input id="<%- id %>" name="<%- id %>" type="text" placeholder="<%- placeholder %>" class="<%- inputsize %> search-query" <% if(required) {%> required <% } %> />
+    <input
+    	id="<%- id %>"
+    	name="<%- id %>"
+    	type="text"
+    	<% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+    	class="<%- inputsize %> search-query"
+    	<% if(required) {%> required <% } %>
+    />
     <% if (helptext.length > 0) { %><p class="help-block"><%- helptext %></p><% } %>
   </div>
 </div>

--- a/assets/js/templates/snippet/textinput.html
+++ b/assets/js/templates/snippet/textinput.html
@@ -2,7 +2,13 @@
 <div class="control-group">
   <label class="control-label" for="<%- id %>"><%- label %></label>
   <div class="controls">
-    <input id="<%- id %>" name="<%- id %>" type="text" placeholder="<%- placeholder %>" class="<%- inputsize %>" <% if(required) {%> required <% } %> />
+    <input id="<%- id %>"
+    	name="<%- id %>"
+    	type="text"
+    	<% if(placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+    	class="<%- inputsize %>"
+    	<% if(required) {%> required <% } %>
+    />
     <% if (helptext.length > 0) { %><p class="help-block"><%- helptext %></p><% } %>
   </div>
 </div>


### PR DESCRIPTION
First of all, thanks for this awesome tool.

I noticed that when you don't want any placeholder in your input fields, you still have the attribute _placeholder=""_, which is quite useless and annoying. This PR addresses this issue.
